### PR TITLE
fix(llm_training): migrate job views to use 'modifiers' instead of 'attrs' for Odoo 17

### DIFF
--- a/llm_observability/__init__.py
+++ b/llm_observability/__init__.py
@@ -1,7 +1,7 @@
 from . import controllers, models, services
 
 
-def post_init_hook(cr, registry):
+def post_init_hook(*args, **kwargs):
     """Initialize observability services after module installation"""
     import logging
 
@@ -10,8 +10,13 @@ def post_init_hook(cr, registry):
     _logger = logging.getLogger(__name__)
     
     try:
-        # Create environment with superuser to access phoenix.config
-        env = Environment(cr, 1, {})
+        if len(args) == 1 and hasattr(args[0], 'cr') and hasattr(args[0], 'registry'):
+            env = args[0]
+        elif len(args) == 2:
+            cr, registry = args
+            env = Environment(cr, 1, {})
+        else:
+            raise ValueError("Unsupported post_init_hook signature")
         
         from .services.fullstack_tracing_service import \
             fullstack_tracing_service

--- a/llm_training/views/llm_training_dataset_views.xml
+++ b/llm_training/views/llm_training_dataset_views.xml
@@ -55,10 +55,11 @@
               />
                         </page>
                         <page
-              string="Training Jobs"
-              name="jobs"
-              attrs="{'invisible': [('job_ids', '=', [])]}"
-            >
+                            string="Training Jobs"
+                            name="jobs"
+                            modifiers="{'invisible': [('job_ids', '=', [])]}"
+                        >
+
                             <field name="job_ids">
                                 <tree>
                                     <field name="name" />

--- a/llm_training/views/llm_training_job_views.xml
+++ b/llm_training/views/llm_training_job_views.xml
@@ -8,43 +8,43 @@
             <form>
                 <header>
                     <button
-            name="action_submit"
-            type="object"
-            string="Submit"
-            class="oe_highlight"
-            attrs="{'invisible': [('state', '!=', 'draft')]}"
-          />
+                        name="action_submit"
+                        type="object"
+                        string="Submit"
+                        class="oe_highlight"
+                        modifiers="{'invisible': [('state', '!=', 'draft')]}"
+                    />
                     <button
-            name="action_check_status"
-            type="object"
-            string="Check Status"
-            attrs="{'invisible': [('state', 'in', ('draft', 'cancelled', 'failed', 'completed'))]}"
-          />
+                        name="action_check_status"
+                        type="object"
+                        string="Check Status"
+                        modifiers="{'invisible': [('state', 'in', ('draft', 'cancelled', 'failed', 'completed'))]}"
+                    />
                     <button
-            name="action_cancel"
-            type="object"
-            string="Cancel"
-            attrs="{'invisible': [('state', 'in', ('completed', 'failed', 'cancelled', 'draft'))]}"
-          />
+                        name="action_cancel"
+                        type="object"
+                        string="Cancel"
+                        modifiers="{'invisible': [('state', 'in', ('completed', 'failed', 'cancelled', 'draft'))]}"
+                    />
                     <field
-            name="state"
-            widget="statusbar"
-            statusbar_visible="draft,validating,preparing,queued,training,completed"
-          />
+                        name="state"
+                        widget="statusbar"
+                        statusbar_visible="draft,validating,preparing,queued,training,completed"
+                    />
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button
-              name="toggle_active"
-              type="object"
-              class="oe_stat_button"
-              icon="fa-archive"
-            >
+                            name="toggle_active"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-archive"
+                        >
                             <field
-                name="active"
-                widget="boolean_toggle"
-                options="{'terminology': 'archive'}"
-              />
+                                name="active"
+                                widget="boolean_toggle"
+                                options="{'terminology': 'archive'}"
+                            />
                         </button>
                     </div>
                     <div class="oe_title">
@@ -55,39 +55,39 @@
                     <group>
                         <group>
                             <field
-                name="provider_id"
-                options="{'no_create': True}"
-                attrs="{'readonly': [('state', '!=', 'draft')]}"
-              />
+                                name="provider_id"
+                                options="{'no_create': True}"
+                                modifiers="{'readonly': [('state', '!=', 'draft')]}"
+                            />
                             <field
-                name="base_model_id"
-                options="{'no_create': True}"
-                attrs="{'readonly': [('state', '!=', 'draft')]}"
-              />
+                                name="base_model_id"
+                                options="{'no_create': True}"
+                                modifiers="{'readonly': [('state', '!=', 'draft')]}"
+                            />
                             <field
-                name="trained_model_name"
-                attrs="{'readonly': [('state', '!=', 'draft')]}"
-              />
+                                name="trained_model_name"
+                                modifiers="{'readonly': [('state', '!=', 'draft')]}"
+                            />
                         </group>
                         <group>
                             <field name="estimated_cost" widget="monetary" />
                             <field
-                name="final_cost"
-                widget="monetary"
-                attrs="{'invisible': [('state', '!=', 'completed')]}"
-              />
+                                name="final_cost"
+                                widget="monetary"
+                                modifiers="{'invisible': [('state', '!=', 'completed')]}"
+                            />
                             <field
-                name="external_job_id"
-                attrs="{'invisible': [('external_job_id', '=', False)]}"
-              />
+                                name="external_job_id"
+                                modifiers="{'invisible': [('external_job_id', '=', False)]}"
+                            />
                         </group>
                     </group>
                     <notebook>
                         <page string="Datasets" name="datasets">
                             <field
-                name="dataset_ids"
-                attrs="{'readonly': [('state', '!=', 'draft')]}"
-              >
+                                name="dataset_ids"
+                                modifiers="{'readonly': [('state', '!=', 'draft')]}"
+                            >
                                 <tree>
                                     <field name="name" />
                                     <field name="file_count" />
@@ -97,48 +97,45 @@
                         </page>
                         <page string="Description" name="description">
                             <field
-                name="description"
-                placeholder="Job description..."
-                nolabel="1"
-              />
+                                name="description"
+                                placeholder="Job description..."
+                                nolabel="1"
+                            />
                         </page>
                         <page string="Hyperparameters" name="hyperparameters">
                             <field
-                name="hyperparameters"
-                widget="ace"
-                attrs="{'readonly': [('state', '!=', 'draft')]}"
-              />
+                                name="hyperparameters"
+                                widget="ace"
+                                modifiers="{'readonly': [('state', '!=', 'draft')]}"
+                            />
                         </page>
                         <page
-              string="Results"
-              name="results"
-              attrs="{'invisible': [('state', 'not in', ('completed', 'failed'))]}"
-            >
+                            string="Results"
+                            name="results"
+                            modifiers="{'invisible': [('state', 'not in', ('completed', 'failed'))]}"
+                        >
                             <group>
                                 <field
-                  name="result_model_id"
-                  attrs="{'invisible': [('result_model_id', '=', False)]}"
-                />
+                                    name="result_model_id"
+                                    modifiers="{'invisible': [('result_model_id', '=', False)]}"
+                                />
                                 <field
-                  name="training_metrics"
-                  widget="ace"
-                  attrs="{'invisible': [('training_metrics', '=', False)]}"
-                />
+                                    name="training_metrics"
+                                    widget="ace"
+                                    modifiers="{'invisible': [('training_metrics', '=', False)]}"
+                                />
                             </group>
                             <group
-                string="Training Logs"
-                attrs="{'invisible': [('training_logs', '=', False)]}"
-              >
+                                string="Training Logs"
+                                modifiers="{'invisible': [('training_logs', '=', False)]}"
+                            >
                                 <field name="training_logs" nolabel="1" />
                             </group>
                         </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field
-            name="message_follower_ids"
-            groups="base.group_user"
-          />
+                    <field name="message_follower_ids" groups="base.group_user" />
                     <field name="message_ids" />
                 </div>
             </form>
@@ -151,12 +148,12 @@
         <field name="model">llm.training.job</field>
         <field name="arch" type="xml">
             <tree
-        decoration-info="state in ('draft', 'validating', 'preparing')"
-        decoration-primary="state in ('queued', 'training')"
-        decoration-success="state == 'completed'"
-        decoration-danger="state == 'failed'"
-        decoration-muted="state == 'cancelled'"
-      >
+                decoration-info="state in ('draft', 'validating', 'preparing')"
+                decoration-primary="state in ('queued', 'training')"
+                decoration-success="state == 'completed'"
+                decoration-danger="state == 'failed'"
+                decoration-muted="state == 'cancelled'"
+            >
                 <field name="name" />
                 <field name="provider_id" />
                 <field name="base_model_id" />
@@ -177,52 +174,16 @@
                 <field name="provider_id" />
                 <field name="base_model_id" />
                 <separator />
-                <filter
-          string="Draft"
-          name="draft"
-          domain="[('state', '=', 'draft')]"
-        />
-                <filter
-          string="In Progress"
-          name="in_progress"
-          domain="[('state', 'in', ('validating', 'preparing', 'queued', 'training'))]"
-        />
-                <filter
-          string="Completed"
-          name="completed"
-          domain="[('state', '=', 'completed')]"
-        />
-                <filter
-          string="Failed"
-          name="failed"
-          domain="[('state', '=', 'failed')]"
-        />
-                <filter
-          string="Cancelled"
-          name="cancelled"
-          domain="[('state', '=', 'cancelled')]"
-        />
-                <filter
-          string="Archived"
-          name="inactive"
-          domain="[('active', '=', False)]"
-        />
+                <filter string="Draft" name="draft" domain="[('state', '=', 'draft')]" />
+                <filter string="In Progress" name="in_progress" domain="[('state', 'in', ('validating', 'preparing', 'queued', 'training'))]" />
+                <filter string="Completed" name="completed" domain="[('state', '=', 'completed')]" />
+                <filter string="Failed" name="failed" domain="[('state', '=', 'failed')]" />
+                <filter string="Cancelled" name="cancelled" domain="[('state', '=', 'cancelled')]" />
+                <filter string="Archived" name="inactive" domain="[('active', '=', False)]" />
                 <group expand="0" string="Group By">
-                    <filter
-            string="Provider"
-            name="group_by_provider"
-            context="{'group_by': 'provider_id'}"
-          />
-                    <filter
-            string="Base Model"
-            name="group_by_model"
-            context="{'group_by': 'base_model_id'}"
-          />
-                    <filter
-            string="Status"
-            name="group_by_state"
-            context="{'group_by': 'state'}"
-          />
+                    <filter string="Provider" name="group_by_provider" context="{'group_by': 'provider_id'}" />
+                    <filter string="Base Model" name="group_by_model" context="{'group_by': 'base_model_id'}" />
+                    <filter string="Status" name="group_by_state" context="{'group_by': 'state'}" />
                 </group>
             </search>
         </field>


### PR DESCRIPTION
The error occurs when loading an XML view (`llm_training_dataset_views.xml` and `llm_training_jobs_views.xml`) where is being using `attrs` or `states` to control the visibility or editability of fields. This was valid in previous versions, but in Odoo 17 a new UI control system was introduced based on client-side JavaScript logic using `modifiers`.
